### PR TITLE
Removed extra null byte from packing command

### DIFF
--- a/SourceQuery/SourceRcon.class.php
+++ b/SourceQuery/SourceRcon.class.php
@@ -66,7 +66,7 @@
 		public function Write( $Header, $String = '' )
 		{
 			// Pack the packet together
-			$Command = Pack( 'VV', ++$this->RconRequestId, $Header ) . $String . "\x00\x00\x00"; 
+			$Command = Pack( 'VV', ++$this->RconRequestId, $Header ) . $String . "\x00\x00"; 
 			
 			// Prepend packet length
 			$Command = Pack( 'V', StrLen( $Command ) ) . $Command;


### PR DESCRIPTION
Removing the extra null seemed to fix issues I had querying newer source servers.
Did older servers ignored the extra characters ?