### PR TITLE
Fix #43 - Only write SERVERDATA_RESPONSE_VALUE once for multi packet responses

### DIFF
--- a/SourceQuery/SourceRcon.php
+++ b/SourceQuery/SourceRcon.php
@@ -146,10 +146,10 @@
 			// See https://developer.valvesoftware.com/wiki/Source_RCON_Protocol#Multiple-packet_Responses
 			if( StrLen( $Data ) >= 4000 )
 			{
+				$this->Write( SourceQuery::SERVERDATA_RESPONSE_VALUE );
+				
 				do
-				{
-					$this->Write( SourceQuery::SERVERDATA_RESPONSE_VALUE );
-					
+				{	
 					$Buffer = $this->Read( );
 					
 					$Buffer->GetLong( ); // RequestID


### PR DESCRIPTION
This fixes the bug where all RCON queries on same SourceQuery object would return empty responses.
