### PR TITLE
Add 7 Days to Die to supported games

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ AppID | Game | Query | RCON | Notes
 115300 | [Call of Duty: Modern Warfare 3](http://store.steampowered.com/app/115300/) | :white_check_mark: | :white_check_mark: | 
 211820 | [Starbound](http://store.steampowered.com/app/211820/) | :white_check_mark: | :white_check_mark: | Call `SetUseOldGetChallengeMethod` method after connecting
 244850 | [Space Engineers](http://store.steampowered.com/app/244850/) | :white_check_mark: | :x: | Add +1 to the server port
+251570 | [7 Days to Die](http://store.steampowered.com/app/251570) | :white_check_mark: | :x: |
 252490 | [Rust](http://store.steampowered.com/app/252490/) | :white_check_mark: | :x: |
 282440 | [Quake Live](http://store.steampowered.com/app/282440) | :white_check_mark: | :x: | Quake Live uses the ZMQ messaging queue protocol for rcon control.
 346110 | [ARK: Survival Evolved](http://store.steampowered.com/app/346110/) | :white_check_mark: | :white_check_mark: | 


### PR DESCRIPTION
Source query protocol works well with 7 Days to Die.