### PR TITLE
[2.x] Fix fclose for socket

### DIFF
--- a/SourceQuery/Socket.php
+++ b/SourceQuery/Socket.php
@@ -27,7 +27,7 @@
 	{
 		public function Close( ) : void
 		{
-			if( $this->Socket !== null )
+			if( $this->Socket )
 			{
 				FClose( $this->Socket );
 				


### PR DESCRIPTION
When closing the socket with fclose, it seems like the `$this->socket` is `false` and `fclose` does not accept boolean:

```php
$query = new SourceQuery;

try {
    $query->connect($this->host, $this->port, 5, SourceQuery::SOURCE); // the host and port are invalid/server is down
} catch (Exception $e) {
    return  [];
}

// Throws: TypeError: fclose(): Argument #1 ($stream) must be of type resource, bool given.
// Line: xpaw\php-source-query-class\SourceQuery\Socket.php:33
$query->disconnect();
```

The code formatting also knocks me off, it seems more related to C# than PSR-7. Are formatting PRs allowed?