### PR TITLE
Update Socket.php

### DIFF
--- a/SourceQuery/Socket.php
+++ b/SourceQuery/Socket.php
@@ -27,7 +27,7 @@
 	{
 		public function Close( ) : void
 		{
-			if( $this->Socket !== null )
+			if( is_resource($this->Socket) )
 			{
 				fclose( $this->Socket );
 				


### PR DESCRIPTION
On PHP >= 8.1 this throws a TypeError
```
Uncaught TypeError: fclose(): Argument #1 ($stream) must be of type resource, bool given in .\vendor\xpaw\php-source-query-class\SourceQuery\Socket.php:32
```

Because a failed connection server sets this to boolean false. Better to check if the parameter passed to `fclose()` is an actual resource/stream.