### PR TITLE
Avoid socket being false when calling destructor

### DIFF
--- a/SourceQuery/Socket.php
+++ b/SourceQuery/Socket.php
@@ -46,6 +46,7 @@
 			
 			if( $ErrNo || $Socket === false )
 			{
+				$this->Socket = null;
 				throw new SocketException( 'Could not create socket: ' . $ErrStr, SocketException::COULD_NOT_CREATE_SOCKET );
 			}
 			


### PR DESCRIPTION
If the FSockOpen returns "false" because of an issue while opening the socket, the SourceQuery::__destruct(), calling the Close() method can fail because you can't FClose a boolean.

```
CRITICAL - 2024-03-22 09:26:04 --> TypeError: fclose(): Argument #1 ($stream) must be of type resource, bool given
in VENDORPATH/xpaw/php-source-query-class/SourceQuery/Socket.php on line 32.
 1 VENDORPATH/xpaw/php-source-query-class/SourceQuery/Socket.php(32): fclose()
 2 VENDORPATH/xpaw/php-source-query-class/SourceQuery/BaseSocket.php(38): xPaw\SourceQuery\Socket->Close()
```

```
CRITICAL - 2024-03-22 09:26:04 --> [Caused by] TypeError: fclose(): Argument #1 ($stream) must be of type resource, bool given
in VENDORPATH/xpaw/php-source-query-class/SourceQuery/Socket.php on line 32.
 1 VENDORPATH/xpaw/php-source-query-class/SourceQuery/Socket.php(32): fclose()
 2 VENDORPATH/xpaw/php-source-query-class/SourceQuery/SourceQuery.php(156): xPaw\SourceQuery\Socket->Close()
 3 VENDORPATH/xpaw/php-source-query-class/SourceQuery/SourceQuery.php(104): xPaw\SourceQuery\SourceQuery->Disconnect()
```