### PR TITLE
Player list cutoff

### DIFF
--- a/SourceQuery/SourceQuery.php
+++ b/SourceQuery/SourceQuery.php
@@ -425,27 +425,34 @@ class SourceQuery
 
 		while( $Count-- > 0 && $Buffer->Remaining( ) > 0 )
 		{
-			$Player = [];
-			$Player[ 'Id' ]    = $Buffer->ReadByte( ); // PlayerID, is it just always 0?
-			$Player[ 'Name' ]  = $Buffer->ReadNullTermString( );
-			$Player[ 'Frags' ] = $Buffer->ReadInt32( );
+			try
+			{
+				$Player = [];
+				$Player[ 'Id' ]    = $Buffer->ReadByte( ); // PlayerID, is it just always 0?
+				$Player[ 'Name' ]  = $Buffer->ReadNullTermString( );
+				$Player[ 'Frags' ] = $Buffer->ReadInt32( );
 
-			// Some servers return a bugged or intentionally huge float way above the php min/max int value
-			// Causes a php warning since php 8.5 in addition to the cast overflow to PHP_INT_MIN
-			// Versions below 8.5 would also return the overflow, but no error
-			$time = $Buffer->ReadFloat32( );
+				// Some servers return a bugged or intentionally huge float way above the php min/max int value
+				// Causes a php warning since php 8.5 in addition to the cast overflow to PHP_INT_MIN
+				// Versions below 8.5 would also return the overflow, but no error
+				$time = $Buffer->ReadFloat32( );
 
-			if ($time > PHP_INT_MAX) {
-				$Player[ 'Time' ] = PHP_INT_MAX;
-			}
-			elseif ($time < PHP_INT_MIN) {
-				$Player[ 'Time' ] = PHP_INT_MIN;
-			}
-			else {
-				$Player[ 'Time' ] = (int)$time;
-			}
+				if ($time > PHP_INT_MAX) {
+					$Player[ 'Time' ] = PHP_INT_MAX;
+				}
+				elseif ($time < PHP_INT_MIN) {
+					$Player[ 'Time' ] = PHP_INT_MIN;
+				}
+				else {
+					$Player[ 'Time' ] = (int)$time;
+				}
 
-			$Player[ 'TimeF' ] = gmdate( ( $Player[ 'Time' ] > 3600 ? 'H:i:s' : 'i:s' ), $Player[ 'Time' ] );
+				$Player[ 'TimeF' ] = gmdate( ( $Player[ 'Time' ] > 3600 ? 'H:i:s' : 'i:s' ), $Player[ 'Time' ] );
+			}
+			catch (InvalidPacketException $e) 
+			{
+				break;
+			}
 
 			$Players[ ] = $Player;
 		}


### PR DESCRIPTION
Some servers / games cut of the packets instead of sending split packets. 
Because of read functions which throw, we loose the hole list parsed so far. By catching it, we can break out of the loop and keep already parsed data. 
This PR stops at this point, as i persoanlly think such a cutoff is not worthy of throwing. 
Yes, list is not complete, but it contains data


To still allow catching outside, one possibility would be:
1) In the method, set `$this->PlayerList[ ] = $Player;` instead of returning a isolated array, we return the property. 
- By using a property set and return, we have access to the data when we throw
2) We catch InvalidPacketException as in the PR
3) In the catch, we rethrow a new type, to make the throw descriptive and very specific
3) Outside world could for example: 
```
try
{
     $players = $query->GetPlayers();
}
catch(PlayerCutoffException $e)
{
    // Even on player cutoffs, im interested in what was parsed already
    $players = $query->PlayerList;
}

// display players in a table here, whatever
var_dump($players)
```



The same thing basicly should be done in rules, but it just reads non throw methods.
Worst thing happening there is a broken key/value pair at the end.



