### PR TITLE
UDP packet split order

### DIFF
--- a/SourceQuery/BaseSocket.php
+++ b/SourceQuery/BaseSocket.php
@@ -107,6 +107,9 @@ abstract class BaseSocket
 			}
 			while( $ReadMore && $SherlockFunction( $Buffer ) );
 
+			// UDP Packets can arrive in wrong order
+			ksort($Packets, SORT_NUMERIC);
+
 			$Data = implode( $Packets );
 
 			// TODO: Test this


### PR DESCRIPTION
Since UDP packets can arrive in random order and implode glues the packets back together in the order they arrive, the header is not on the position we expect, leading to packet header mismatch errors.

`$Buffer->Set( substr( $Data, 4 ) );` also cuts the wrong bytes in those cases ( not that the request would succeed, since the header is not in first packet anyway ).

That cut is supposed to cut -1 off the first packet which the engine still includes when splitting packets
Can we be sure that every game does the same? Forked engine, hooks? Maybe they split differently?

As precaution, maybe we should only cutoff when we actually encounter -1 at the start?
If a game not includes that -1, we would strip of the header we need for validation